### PR TITLE
Factorio 0.15 update!

### DIFF
--- a/src/info.json
+++ b/src/info.json
@@ -1,10 +1,10 @@
 {
   "name": "Compression Chests",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "title": "Compression Chests",
   "author": "Rseding91",
   "homepage": "http://www.factorioforums.com/forum/viewtopic.php?f=14&t=4845&p=36922#p36922",
   "dependencies": ["base"],
   "description": "Store massive amounts of one item type in a single chest.",
-  "factorio_version": "0.14"
+  "factorio_version": "0.15"
 }

--- a/src/locale/en/compression.cfg
+++ b/src/locale/en/compression.cfg
@@ -1,38 +1,38 @@
 [item-description]
-compression-chest = Stores a virtually unlimited number of one item type.
-compression-power-pole = Powers Compression Chests in a 5x5 centered on the pole.
-compression-mover = Hold while mining a Compression chest.
-compression-chest-mined-1 = Contains stored items.
-compression-chest-mined-2 = Contains stored items.
-compression-chest-mined-3 = Contains stored items.
-compression-chest-mined-4 = Contains stored items.
-compression-chest-mined-5 = Contains stored items.
+compression-chest=Stores a virtually unlimited number of one item type.
+compression-power-pole=Powers Compression Chests in a 5x5 centered on the pole.
+compression-mover=Hold while mining a Compression chest.
+compression-chest-mined-1=Contains stored items.
+compression-chest-mined-2=Contains stored items.
+compression-chest-mined-3=Contains stored items.
+compression-chest-mined-4=Contains stored items.
+compression-chest-mined-5=Contains stored items.
 
 [item-name]
-compression-chest = Compression Chest
-compression-power-pole = Compression Power Pole
-compression-mover = Compression Chest Mover
-reset-compression-chests = DEBUG-ITEM: Resets the picked-up compression chest list
+compression-chest=Compression Chest
+compression-power-pole=Compression Power Pole
+compression-mover=Compression Chest Mover
+reset-compression-chests=DEBUG-ITEM: Resets the picked-up compression chest list
 
 [entity-name]
-compression-chest = Compression Chest
-compression-power-pole = Compression Power Pole
-compression-power-pole-field = Compression Power Pole
-compression-chest-mined-1 = Compression Chest
-compression-chest-mined-2 = Compression Chest
-compression-chest-mined-3 = Compression Chest
-compression-chest-mined-4 = Compression Chest
-compression-chest-mined-5 = Compression Chest
+compression-chest=Compression Chest
+compression-power-pole=Compression Power Pole
+compression-power-pole-field=Compression Power Pole
+compression-chest-mined-1=Compression Chest
+compression-chest-mined-2=Compression Chest
+compression-chest-mined-3=Compression Chest
+compression-chest-mined-4=Compression Chest
+compression-chest-mined-5=Compression Chest
 
 [entity-description]
-compression-chest = Stores a virtually unlimited number of one item type.
-compression-power-pole = Powers Compression Chests in a 5x5 centered on the pole.
-compression-power-pole-field = Powers Compression Chests in a 5x5 centered on the pole.
+compression-chest=Stores a virtually unlimited number of one item type.
+compression-power-pole=Powers Compression Chests in a 5x5 centered on the pole.
+compression-power-pole-field=Powers Compression Chests in a 5x5 centered on the pole.
 
 [technology-name]
-move-compression-chest = Move Compression Chests
-pickup-compression-chest-count = Pick up Compression Chests count
+move-compression-chest=Move Compression Chests
+pickup-compression-chest-count=Pick up Compression Chests count
 
 [technology-description]
-move-compression-chest = Allows Compression Chests to be moved while retaining their contents.
-pickup-compression-chest-count = Adds to the maximum count of Compression Chests that can be picked up at the same time while retaining their contents.
+move-compression-chest=Allows Compression Chests to be moved while retaining their contents.
+pickup-compression-chest-count=Adds to the maximum count of Compression Chests that can be picked up at the same time while retaining their contents.

--- a/src/prototypes/entities.lua
+++ b/src/prototypes/entities.lua
@@ -94,7 +94,7 @@ data:extend(
 				line_length = 1,
 				frame_count = 1,
 				shift = {0.49145, -0.25},
-				animation_speed = 0
+				animation_speed = 1
 			},
 			charge_cooldown = 45,
 			discharge_cooldown = 90,

--- a/src/prototypes/technologies.lua
+++ b/src/prototypes/technologies.lua
@@ -7,7 +7,7 @@ data:extend(
 			type = "technology",
 			name = "move-compression-chest",
 			icon = "__Compression Chests__/graphics/Picked up chest count.png",
-			prerequisites = {"logistics-3", "alien-technology"},
+			prerequisites = {"logistics-3"},
 			effects =
 			{
 				{
@@ -22,8 +22,7 @@ data:extend(
 				{
 					{"science-pack-1", 2},
 					{"science-pack-2", 2},
-					{"science-pack-3", 2},
-					{"alien-science-pack", 1}
+					{"science-pack-3", 2}
 				},
 				time = 45,
 				
@@ -44,8 +43,7 @@ data:extend(
 				{
 					{"science-pack-1", 2},
 					{"science-pack-2", 2},
-					{"science-pack-3", 2},
-					{"alien-science-pack", 1}
+					{"science-pack-3", 2}
 				},
 				time = 45,
 				
@@ -65,8 +63,7 @@ data:extend(
 				{
 					{"science-pack-1", 2},
 					{"science-pack-2", 2},
-					{"science-pack-3", 2},
-					{"alien-science-pack", 1}
+					{"science-pack-3", 2}
 				},
 				time = 45,
 				
@@ -86,8 +83,7 @@ data:extend(
 				{
 					{"science-pack-1", 3},
 					{"science-pack-2", 3},
-					{"science-pack-3", 2},
-					{"alien-science-pack", 1}
+					{"science-pack-3", 2}
 				},
 				time = 45,
 				
@@ -108,8 +104,7 @@ data:extend(
 				{
 					{"science-pack-1", 3},
 					{"science-pack-2", 3},
-					{"science-pack-3", 3},
-					{"alien-science-pack", 2}
+					{"science-pack-3", 3}
 				},
 				time = 45,
 				
@@ -130,8 +125,7 @@ data:extend(
 				{
 					{"science-pack-1", 3},
 					{"science-pack-2", 3},
-					{"science-pack-3", 3},
-					{"alien-science-pack", 3}
+					{"science-pack-3", 3}
 				},
 				time = 45,
 				


### PR DESCRIPTION
Made it compatible with Factorio 0.15.

- Changed the locale.cfg syntax to make it work. Now you can't have spaces between the locale variable, the equal sign, or the string.
- Deleted all alien-related content, as in 0.15 these got removed.
- Also, there was an animation problem due to the animation time being 0, so I changed it to 1 and it works now.

If you want to rebalance the mod researches of crafting, it's up to you. 
But if you are really going to do it, read this: [Alien Science Pack - Factorio Wiki](https://wiki.factorio.com/Alien_science_pack).